### PR TITLE
Search for closest persister

### DIFF
--- a/lib/find_closest_persister.js
+++ b/lib/find_closest_persister.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var findClosestPersister = function (dataStore, path) {
+  if (!dataStore) throw new Error('Called persist with no defined data store');
+
+  while (!(dataStore[path])) {
+    let parts = path.split('.');
+    parts.pop();
+    path = parts.join('.');
+
+    if (path.length === 0) {
+      throw new Error('Called persist with no defined persister.');
+    }
+  }
+
+  return dataStore[path].persister;
+};
+
+module.exports = findClosestPersister;

--- a/lib/state_trooper.js
+++ b/lib/state_trooper.js
@@ -17,6 +17,7 @@ var flatten = _.flatten;
 var partial = _.partial;
 
 var cursor = require('./cursor');
+var findClosestPersister = require('./find_closest_persister');
 
 var buildUpdatedState = function (oldState, pathToNewState, newState) {
   if (pathToNewState) {
@@ -85,7 +86,7 @@ var StateTrooper = {
     go(function* () {
       while (true) {
         var path = yield take(persistCh);
-        var persister = dataStore[path].persister;
+        var persister = findClosestPersister(dataStore, path);
 
         if (persister) {
           persister(setCh, path, getStateByPath(currentState, path));

--- a/test/find_closest_persister_test.js
+++ b/test/find_closest_persister_test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const expect = require('expect.js');
+const findClosestPersister = require('../lib/find_closest_persister');
+
+describe('findClosestPersister', function () {
+  var dataStore, path;
+
+  describe('with a persister specified at the top level of the hierarchy', function () {
+    beforeEach(function () {
+      dataStore = {
+        'foo': {
+          persister: 'mock persister value'
+        }
+      };
+    });
+
+    it('can find that persister given a path at a lower level of the hierarchy', function () {
+      path = 'foo.bar.baz.what';
+
+      expect(findClosestPersister(dataStore, path)).to.eql('mock persister value');
+    });
+  });
+
+  describe('with a persister specified at a sub level of the hierarchy', function () {
+    beforeEach(function () {
+      dataStore = {
+        'foo.bar': {
+          persister: 'another mock persister value'
+        }
+      };
+    });
+
+    it('can find that persister given its exact path', function () {
+      path = 'foo.bar';
+
+      expect(findClosestPersister(dataStore, path)).to.eql('another mock persister value');
+    });
+  });
+
+});
+


### PR DESCRIPTION
@hojberg 

Add `find_closest_persister` module, unit test it, use `findClosestPersister` in `state_trooper` instead of assuming we always get the exact path.

Throws an error if no persister is defined on the data store, or if the data store doesn't exist at all. I wanted to test this but the `expect().to.throw()` matcher does not seem to work as advertised. 