### PR TITLE
Cursor has remove function

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -9,11 +9,11 @@ var partial = _.partial;
 
 var ObjectPath = require('object-path');
 
-var refine = function (value, setCh, persistCh, oldPath, newPath) {
+var refine = function (value, setCh, removeCh, persistCh, oldPath, newPath) {
   var refinedValue = ObjectPath.get(value, newPath);
   var refinedPath = oldPath ? [oldPath, newPath].join('.') : newPath;
 
-  return cursor(refinedValue, refinedPath, setCh, persistCh);
+  return cursor(refinedValue, refinedPath, setCh, removeCh, persistCh);
 };
 
 var set = function (ch, path, newValue) {
@@ -28,12 +28,19 @@ var persist = function (ch, path) {
   });
 };
 
-var cursor = function (value, path, setCh, persistCh) {
+var remove = function (removeCh, path, value) {
+  go(function* () {
+    yield put(removeCh, { path: path, value: value });
+  });
+};
+
+var cursor = function (value, path, setCh, removeCh, persistCh) {
   return {
     path:     path,
     value:    value,
     set:      partial(set, setCh, path),
-    refine:   partial(refine, value, setCh, persistCh, path),
+    remove:   partial(remove, removeCh, path, value),
+    refine:   partial(refine, value, setCh, removeCh, persistCh, path),
     persist:  partial(persist, persistCh, path)
   };
 };

--- a/lib/state_trooper.js
+++ b/lib/state_trooper.js
@@ -51,6 +51,12 @@ var getStateByPath = function (state, path) {
   return ObjectPath.get(state, path);
 };
 
+var removeStateAtPath = function (oldState, path) {
+  let clonedState = clone(oldState);
+  ObjectPath.del(clonedState, path);
+  return clonedState;
+};
+
 var StateTrooper = {
   patrol: function (stateDescriptor) {
     var currentState = clone(stateDescriptor.state);
@@ -60,8 +66,11 @@ var StateTrooper = {
     var mainCursorCh = chan();
 
     var setCh = chan();
+    var removeCh = chan();
     var persistCh = chan();
-    var createCursor = partial(cursor, _, '', setCh, persistCh);
+    var createCursor = partial(cursor, _, '', setCh, removeCh, persistCh);
+
+    var changes = [];
 
     // put initial blank cursor
     putCursorOnChan(mainCursorCh, createCursor(currentState));
@@ -77,7 +86,20 @@ var StateTrooper = {
     go(function* () {
       while (true) {
         var change = yield take(setCh);
+
+        changes.push({action: 'set', path: change.path, value: change.value});
         currentState = buildUpdatedState(currentState, change.path, change.value);
+        putCursorOnChan(mainCursorCh, createCursor(currentState));
+      }
+    });
+
+    // react to any new data on the remove channel
+    go(function* () {
+      while (true) {
+        var change = yield take(removeCh);
+
+        changes.push({action: 'remove', path: change.path, value: change.value });
+        currentState = removeStateAtPath(currentState, change.path);
         putCursorOnChan(mainCursorCh, createCursor(currentState));
       }
     });
@@ -89,8 +111,11 @@ var StateTrooper = {
         var persister = findClosestPersister(dataStore, path);
 
         if (persister) {
+          persister(setCh, path, getStateByPath(currentState, path), changes.pop());
           persister(setCh, path, getStateByPath(currentState, path));
         }
+
+        changes = [];
       }
     });
 

--- a/test/cursor_test.js
+++ b/test/cursor_test.js
@@ -21,12 +21,14 @@ describe('cursor', function () {
   describe('()', function () {
     let cur;
     let setCh;
+    let removeCh;
     let persistCh;
 
     beforeEach(function () {
       setCh = chan();
+      removeCh = chan();
       persistCh = chan();
-      cur = cursor(state, '', setCh, persistCh);
+      cur = cursor(state, '', setCh, removeCh, persistCh);
     });
 
     it('returns a cursor bound to state', function () {
@@ -47,6 +49,17 @@ describe('cursor', function () {
           cur.set('newval');
           const change = yield take(setCh);
           expect(change).to.eql({ path: '', value: 'newval'});
+          done();
+        });
+      });
+    });
+
+    describe('#remove', function () {
+      it('puts a change on the cursors remove chan', function (done) {
+        go(function* () {
+          cur.refine('foo').refine('bar').remove();
+          const change = yield take(removeCh);
+          expect(change).to.eql({ path: 'foo.bar', value: { baz: 42 }});
           done();
         });
       });


### PR DESCRIPTION
Add the remove function, intended to be used for deleting an individual object from your store. Refine the cursor to that object, call remove, and call persist. 

From commit msg:

In order to remember what was removed, we now store changes
to the data store (since the last time persist was called).

At the moment, we only expose the most recent change
to the persister you define in your app code. So if that persister
needs the id of the thing that was deleted, *don't call remove more
than once in between persist calls*.

In the future, we want to iterate through all the
changes since the last persist.