### PR TITLE
Use ImmutableJS as internal data store

### DIFF
--- a/lib/build_updated_state.js
+++ b/lib/build_updated_state.js
@@ -1,14 +1,9 @@
-import ObjectPath from 'object-path';
-import clone from 'clone';
-
 const buildUpdatedState = function (oldState, pathToNewState, newState) {
   if (pathToNewState) {
-    const changedState = clone(oldState);
-    ObjectPath.set(changedState, pathToNewState, newState);
-    return changedState;
+    return oldState.setIn(pathToNewState.split('.'), newState);
   }
   else {
-    return clone(newState);
+    return newState;
   }
 };
 

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -1,29 +1,42 @@
-import { isObject, isFunction, partial, defaults, map, filter, find, isArray } from 'underscore';
-import ObjectPath from 'object-path';
+import { partial, map, filter, find, isArray } from 'underscore';
+import Immutable from 'immutable';
 import putOnChan from './put_on_chan';
 
 const hasSameValue = function (valueA, cursorB) {
-  return isEqual(valueA, cursorB.value);
+  return isEqual(valueA, Immutable.fromJS(cursorB.deref()));
 };
 
 const isEqual = function (valueA, valueB) {
-  return JSON.stringify(valueA) === JSON.stringify(valueB);
+  if (valueA) {
+    return Immutable.is(valueA, valueB);
+  }
+  else {
+    return valueA === valueB;
+  }
 };
 
-// "mutations"
-const replace = function (ch, path, oldValue, newValue) {
+const deref = function (value) {
+  return value ? value.toJS() : value;
+};
+
+const putOnChanIfChanged = function (ch, path, oldValue, newValue) {
   if (isEqual(oldValue, newValue)) return;
   putOnChan(ch, { path: path, value: newValue});
 };
 
+// "mutations"
+const replace = function (ch, path, oldValue, newValue) {
+  putOnChanIfChanged(ch, path, oldValue, Immutable.fromJS(newValue));
+};
+
 const set = function (ch, path, oldValue, change) {
-  const newValue = defaults(change, oldValue);
-  replace(ch, path, oldValue, newValue);
+  const newValue = Immutable.fromJS(oldValue).merge(change);
+  putOnChan(ch, { path: path, value: newValue});
 };
 
 const add = function (ch, path, oldValue, addition) {
-  const newValue = oldValue.concat(addition);
-  replace(ch, path, oldValue, newValue);
+  const newValue = oldValue.push(addition);
+  putOnChan(ch, { path: path, value: newValue});
 };
 
 const remove = function (removeCh, path, value) {
@@ -32,7 +45,7 @@ const remove = function (removeCh, path, value) {
 
 // refining
 const refine = function (value, setCh, removeCh, fetchCh, persistCh, oldPath, newPath) {
-  const refinedValue = ObjectPath.get(value, newPath);
+  const refinedValue = value.getIn(newPath.split('.'));
   const refinedPath = oldPath ? [oldPath, newPath].join('.') : newPath;
 
   return cursor(refinedValue, refinedPath, setCh, removeCh, fetchCh, persistCh);
@@ -40,42 +53,34 @@ const refine = function (value, setCh, removeCh, fetchCh, persistCh, oldPath, ne
 
 // array helpers
 const cMap = function (value, mapper) {
-  return map(value, (v, i) => mapper(cursor.refine(i), i));
-};
-
-const cFilter = function (value, filterer) {
-  return filter(value, (v, i) => filterer(cursor.refine(i), i));
-};
-
-const cFind = function (value, finder) {
-  return find(value, (v, i) => finder(cursor.refine(i), i));
+  return value.map((v, i) => mapper(cursor.refine(i), i));
 };
 
 const cursor = function (value, path, setCh, removeCh, fetchCh, persistCh) {
+  const imVal = typeof value.toJS === 'function' ? value : Immutable.fromJS(value);
+
   let o = {
     path:     path,
-    value:    value,
+    deref:    partial(deref, imVal),
 
-    replace:  partial(replace, setCh, path, value),
-    remove:   partial(remove, removeCh, path, value),
+    replace:  partial(replace, setCh, path, imVal),
+    remove:   partial(remove, removeCh, path, imVal),
 
-    refine:   partial(refine, value, setCh, removeCh, fetchCh, persistCh, path),
+    refine:   partial(refine, imVal, setCh, removeCh, fetchCh, persistCh, path),
 
     persist:  partial(putOnChan, persistCh, path),
     fetch:    partial(putOnChan, fetchCh, path),
 
-    hasSameValue:  partial(hasSameValue, value)
+    hasSameValue:  partial(hasSameValue, imVal)
   };
 
-  if (isArray(value)) {
+  if (Immutable.List.isList(imVal)) {
     // array specific operations
-    o.map     = partial(cMap, value);
-    o.filter  = partial(cFilter, value);
-    o.find    = partial(cFind, value);
-    o.add     = partial(add, setCh, path, value);
+    o.map = partial(cMap, imVal);
+    o.add = partial(add, setCh, path, imVal);
   }
-  else if (isObject(value) && !isFunction(value)) {
-    o.set     = partial(set, setCh, path, value);
+  if (Immutable.Map.isMap(imVal)) {
+    o.set = partial(set, setCh, path, imVal);
   }
 
   return o;

--- a/lib/get_state_by_path.js
+++ b/lib/get_state_by_path.js
@@ -1,7 +1,5 @@
-import ObjectPath from 'object-path';
-
 const getStateByPath = function (state, path) {
-  return ObjectPath.get(state, path);
+  return state.get(path.split('.'));
 };
 
 export default getStateByPath;

--- a/lib/patrol.js
+++ b/lib/patrol.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import clone from 'clone';
+import Immutable from 'immutable';
 import { go, chan, take, put } from '../vendor/js-csp';
 
 import cursor from './cursor';
@@ -15,8 +15,7 @@ const findClosestPersister = partial(findClosestTransmitter, 'persister');
 const findClosestFetcher = partial(findClosestTransmitter, 'fetcher');
 
 const patrol = function (stateDescriptor) {
-  let currentState = clone(stateDescriptor.state);
-
+  let currentState = Immutable.fromJS(stateDescriptor.state);
   const dataStore = stateDescriptor.dataStore;
 
   const mainCursorCh = chan();

--- a/lib/remove_state_at_path.js
+++ b/lib/remove_state_at_path.js
@@ -1,10 +1,5 @@
-import ObjectPath from 'object-path';
-import clone from 'clone';
-
 const removeStateAtPath = function (oldState, path) {
-  const clonedState = clone(oldState);
-  ObjectPath.del(clonedState, path);
-  return clonedState;
+  return oldState.removeIn(path.split('.'));
 };
 
 export default removeStateAtPath;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
   },
   "homepage": "https://github.com/swipely/state-trooper",
   "dependencies": {
-    "clone": "^0.1.18",
     "expect.js": "^0.3.1",
+    "immutable": "^3.7.4",
     "mocha": "^1.21.5",
-    "object-path": "0.6.0",
     "underscore": "1.7.0"
   },
   "devDependencies": {

--- a/test/cursor_test.js
+++ b/test/cursor_test.js
@@ -27,7 +27,7 @@ describe('cursor', () => {
     });
 
     it('returns a cursor bound to state', () => {
-      expect(cur.value).to.eql({ foo: { bar: { baz: 42 }}});
+      expect(cur.deref()).to.eql({ foo: { bar: { baz: 42 }}});
     });
 
     describe('#hasSameValue', () => {
@@ -47,7 +47,7 @@ describe('cursor', () => {
     describe('#refine', () => {
       it('returns a new cursor bound to the refined state', () => {
         const refined = cur.refine('foo.bar');
-        expect(refined.value).to.eql({baz: 42});
+        expect(refined.deref()).to.eql({baz: 42});
         expect(refined.path).to.be('foo.bar');
       });
     });
@@ -55,7 +55,7 @@ describe('cursor', () => {
     describe('#replace', () => {
       it('puts a complete change on the cursors set chan', (done) => {
         go(function* () {
-          cur.set('newval');
+          cur.replace('newval');
           const change = yield take(setCh);
           expect(change).to.eql({ path: '', value: 'newval'});
           done();
@@ -68,7 +68,8 @@ describe('cursor', () => {
         go(function* () {
           cur.refine('foo').refine('bar').remove();
           const change = yield take(removeCh);
-          expect(change).to.eql({ path: 'foo.bar', value: { baz: 42 }});
+          expect( change.path ).to.eql('foo.bar');
+          expect( change.value.toJS() ).to.eql({baz: 42});
           done();
         });
       });
@@ -88,7 +89,8 @@ describe('cursor', () => {
           go(function* () {
             cur.set({foo: 'bar'});
             const change = yield take(setCh);
-            expect(change).to.eql({ path: '', value: {foo: 'bar', baz: 'beep'}});
+            expect( change.path ).to.eql('');
+            expect( change.value.toJS() ).to.eql({foo: 'bar', baz: 'beep'});
             done();
           });
         });
@@ -102,14 +104,6 @@ describe('cursor', () => {
 
       it('exposes #map', () => {
         expect( cur.map ).to.be.a('function');
-      });
-
-      it('exposes #find', () => {
-        expect( cur.find ).to.be.a('function');
-      });
-
-      it('exposes #filter', () => {
-        expect( cur.filter ).to.be.a('function');
       });
     });
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -37,17 +37,17 @@ go(function*() {
 
   let cur, c, x;
   while(cur = yield take(ch)) {
-    console.log(cur.value);
+    console.log(cur.deref());
 
     // simulate component modifying state
     c = cur.refine('bio');
 
-    if (c.value === null) {
-      c.set({ foo: 'bar' });
+    if (c.deref() === null) {
+      c.replace({ foo: 'bar' });
     }
-    else if (c.value.foo === 'bar') {
+    else if (c.deref().foo === 'bar') {
       x = c.refine('foo');
-      x.set('baz');
+      x.replace('baz');
     }
   }
 });

--- a/test/state_trooper_test.js
+++ b/test/state_trooper_test.js
@@ -33,7 +33,7 @@ describe('StateTrooper', function () {
     it('puts a cursor on the cursor chan', function () {
       go(function* () {
         let cursor = yield take(cursorChan);
-        expect( cursor.value ).to.eql({ foo: 'bar' });
+        expect( cursor.deref() ).to.eql({ foo: 'bar' });
       });
     });
 
@@ -43,7 +43,7 @@ describe('StateTrooper', function () {
           let cursor = yield take(cursorChan);
           yield put(fetchChan, { path: 'foo', value: 'baz' });
           cursor = yield take(cursorChan);
-          expect( cursor.value ).to.eql({ foo: 'baz' });
+          expect( cursor.deref() ).to.eql({ foo: 'baz' });
           done();
         });
       });
@@ -55,7 +55,7 @@ describe('StateTrooper', function () {
           let cursor = yield take(cursorChan);
           cursor.set({ foo: 'baz' });
           cursor = yield take(cursorChan);
-          expect( cursor.value ).to.eql({ foo: 'baz' });
+          expect( cursor.deref() ).to.eql({ foo: 'baz' });
           done();
         });
       });
@@ -70,7 +70,7 @@ describe('StateTrooper', function () {
           yield take(csp.timeout(1));
           yield put(persistChan, { path: 'foo', value: 'baz' });
           cursor = yield take(cursorChan);
-          expect( cursor.value ).to.eql({ foo: 'baz' });
+          expect( cursor.deref() ).to.eql({ foo: 'baz' });
           done();
         });
       });


### PR DESCRIPTION
Use ImmutableJS to maintain the state in the internals of StateTrooper. The ImmutableJS data structures will not at this point bleed through to the developer code.

**Performance**
Immutable adds improved and consistent performance to state changes. The main performance problem thats solved is with `clone`. Which grew slower as data was added. Here’s some before and after stats of a simple `cursor.replace` call.

With `clone`:
~11ms for a large data structure and ~85ms after adding 5x more data.

With ImmutableJS:
~4ms for that same data structure and ~4ms after adding 5x more data.

The test data was a large deeply nested structure with both large arrays and objects.

**API Changes**
The biggest change for the developer is that `cursor.value` has been replaced with `cursor.deref()`. This function call converts the Immutable data structure into a normal JS structure which is returned.

@AdamEdgett @barnabyc @ermanc @flahertyb 