### PR TITLE
Do initial fetch when option evaluates as true

### DIFF
--- a/src/patrol.js
+++ b/src/patrol.js
@@ -33,7 +33,7 @@ const patrol = function (stateDescriptor) {
 
   // fetch initial data
   each(dataStore, (conf, path) => {
-    if (conf.fetcher && conf.initialFetch !== false) {
+    if (conf.fetcher && conf.initialFetch) {
       conf.fetcher(rootCursor.refine(path), rootCursor, conf.query);
     }
   });


### PR DESCRIPTION
undefined value was previously triggering the initial fetch

Any reason this was checking for not false instead?
For context, I was passing a variable that was either undefined or true and the initial fetch was unexpectedly getting fired in both situations

@hojberg 