### PR TITLE
Add callback to various mutation methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Application State Manager",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --compilers js:babel/register test/**_test.js",
+    "test": "./node_modules/mocha/bin/mocha --reporter dot --compilers js:babel/register test/**_test.js",
     "prepublish": "babel src/ -d dist/"
   },
   "repository": {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -26,20 +26,20 @@ const derefJS = memoize(
 );
 
 // mutations and data store interactions
-function replace(ch, path, value) {
-  update(ch, { path, value: Immutable.fromJS(value), action: 'replace' });
+function replace(ch, path, value, callback = null) {
+  update(ch, { path, value: Immutable.fromJS(value), action: 'replace', callback: callback });
 }
 
-function set(ch, path, value) {
-  update(ch, { path, value: Immutable.fromJS(value), action: 'set' });
+function set(ch, path, value, callback = null) {
+  update(ch, { path, value: Immutable.fromJS(value), action: 'set', callback: callback });
 }
 
-function add(ch, path, value) {
-  update(ch, { path, value: Immutable.fromJS(value), action: 'add' });
+function add(ch, path, value, callback = null) {
+  update(ch, { path, value: Immutable.fromJS(value), action: 'add', callback: callback });
 }
 
-function remove(ch, path, value) {
-  update(ch, { path, value, action: 'remove' });
+function remove(ch, path, value, callback = null) {
+  update(ch, { path, value, action: 'remove', callback: callback });
 }
 
 function persist(ch, path) {

--- a/src/patrol.js
+++ b/src/patrol.js
@@ -63,7 +63,7 @@ const patrol = function (stateDescriptor) {
         rootCursor = createCursor(currentState);
 
         if (typeof update.callback === 'function') {
-          update.callback(rootCursor.refine(update.path));
+          update.callback(rootCursor.refine(update.path), rootCursor);
         }
 
         putOnChan(mainCursorCh, rootCursor);

--- a/src/patrol.js
+++ b/src/patrol.js
@@ -61,6 +61,11 @@ const patrol = function (stateDescriptor) {
         unpersistedChanges.push(update);
         currentState = applyStateChange(currentState, update);
         rootCursor = createCursor(currentState);
+
+        if (typeof update.callback === 'function') {
+          update.callback(rootCursor.refine(update.path));
+        }
+
         putOnChan(mainCursorCh, rootCursor);
       }
     }

--- a/test/cursor_test.js
+++ b/test/cursor_test.js
@@ -51,8 +51,20 @@ describe('cursor', () => {
         go(function* () {
           cur.replace('newval');
           const change = yield take(updateCh);
-          expect(change).to.eql({ action: 'replace', path: [], value: 'newval'});
+          expect(change).to.eql({ action: 'replace', path: [], value: 'newval', callback: null});
           done();
+        });
+      });
+
+      describe('with a callback', () => {
+        it('has a callback in the replace state change on the update chan', (done) => {
+          go(function* () {
+            const cb = (x) => x;
+            cur.replace('newval', cb);
+            const change = yield take(updateCh);
+            expect(change).to.eql({ action: 'replace', path: [], value: 'newval', callback: cb });
+            done();
+          });
         });
       });
     });

--- a/test/state_trooper_test.js
+++ b/test/state_trooper_test.js
@@ -51,6 +51,20 @@ describe('StateTrooper', function () {
         });
       });
     });
+
+    describe('cursor.replace', () => {
+      describe('with a callback', () => {
+        it('calls the callback with the new cursor', (done) => {
+          go(function* () {
+            let cursor = yield take(cursorChan);
+            cursor.refine('foo').replace('beep', (newCur) => {
+              expect( newCur.deref() ).to.eql('beep');
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 
 });

--- a/test/state_trooper_test.js
+++ b/test/state_trooper_test.js
@@ -57,8 +57,9 @@ describe('StateTrooper', function () {
         it('calls the callback with the new cursor', (done) => {
           go(function* () {
             let cursor = yield take(cursorChan);
-            cursor.refine('foo').replace('beep', (newCur) => {
+            cursor.refine('foo').replace('beep', (newCur, rootCur) => {
               expect( newCur.deref() ).to.eql('beep');
+              expect( rootCur.refine('foo').deref() ).to.eql('beep');
               done();
             });
           });


### PR DESCRIPTION
Add a callback to #replace, #set, #add and #remove that gets called with
when that change has been made to the appropriately refined cursor