### PR TITLE
Guard against missing hashCode function

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -22,7 +22,7 @@ function deref(value) {
 
 const derefJS = memoize(
   convertToNative,
-  (value) => isEmpty(value) || value.hashCode ? value : value.hashCode()
+  (value) => (isEmpty(value) || typeof value.hashCode !== 'function') ? value : value.hashCode()
 );
 
 // mutations and data store interactions


### PR DESCRIPTION
Complex data structures like moments do not get translated into
immutableJS values and thus wont have the hashCode function.
This improves the guarding against that (and fixes a negation bug)